### PR TITLE
Fixes for apache lab

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,19 +36,22 @@
 # Copyright 2013 Your name here, unless otherwise noted.
 #
 class apache inherits apache::params {
+
   package { 'apache':
-    name   => $apache::params::package,
     ensure => present,
+    name   => $apache::params::package,
   }
+
   file { 'apache_config':
-    path    => $apache::params::config,
     ensure  => file,
-    source  => 'puppet:///modules/apache/${operatingsystem}.conf',
+    path    => $apache::params::config,
+    source  => "puppet:///modules/apache/${facts['os']['family']}.conf",
     require => Package['apache'],
   }
+
   service { 'apache':
-    name      => $apache::params::service,
     ensure    => running,
+    name      => $apache::params::service,
     enable    => true,
     subscribe => File['apache_config'],
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,20 +1,23 @@
+#
 class apache::params {
-  case $operatingsystem {
-    'redhat': {
-      $package = 'httpd'
-      $config  = '/etc/httpd/conf/httpd.conf'
-      $service = 'httpd'
+  case $facts['os']['family'] {
+    'RedHat': {
+      $package  = 'httpd'
+      $config   = '/etc/httpd/conf/httpd.conf'
+      $service  = 'httpd'
     }
-    'debian': {
-      $package = 'apache2'
-      $config  = '/etc/apache2/apache2.conf'
-      $service = 'apache2'
+    'Debian': {
+      $package  = 'apache2'
+      $config   = '/etc/apache2/apache2.conf'
+      $service  = 'apache2'
     }
     'windows': {
-      $package = 'apache-httpd'
-      $config = 'C:/Users/Administrator/AppData/Roaming/Apache24/conf/httpd.conf'
-      $service = 'apache'
+      $package  = 'apache-httpd'
+      $config   = 'C:/Users/Administrator/AppData/Roaming/Apache24/conf/httpd.conf'
+      Package { provider => chocolatey, }
+    }
+    default: {
+      notice('OS not supported')
     }
   }
 }
-


### PR DESCRIPTION
# init.pp
ensure should be the first attribute or it creates warnings in pdk validate. 
We should be using `facts['os']['family']` and not `$operatingsystem` we teach this is taught in lesson 8 "Accessing facts".

# params.pp
We need a default in the case statement so we conform to lesson 11 "code defensively".
We need to use `facts['os']['family']` and not `$operatingsystem` we teach this is taught in lesson 8 "Accessing facts".
We need to specify chocolatey as a provider for the package or lab 14.2 will fail on the Windows machine.
Matching the case of the OS types sop they match what facter is returning. 



